### PR TITLE
feat : Transform 회전 관련 함수 수정, ModelEditor 다중 .fbx 로딩 기능 추가

### DIFF
--- a/Project/Engine/CLevelEditor.cpp
+++ b/Project/Engine/CLevelEditor.cpp
@@ -772,7 +772,7 @@ void CLevelEditor::render_Viewport()
                 CCamera* pCam = CRenderMgr::GetInst()->GetMainCamera();
                 Vec3 pos = pCam->Transform()->GetWorldPos();
                 Vec3 dir = pCam->Transform()->GetWorldDir(DIR_TYPE::FRONT);
-                pos += dir.Normalize() * 5.f;
+                pos += dir.Normalize() * 5.f * CPhysicsMgr::GetInst()->GetPPM();
                 pObj->Transform()->SetLocalPos(pos);
 
                 GamePlayStatic::SpawnGameObject(pObj, pObj->GetLayerIdx());

--- a/Project/Engine/CLevelMgr.cpp
+++ b/Project/Engine/CLevelMgr.cpp
@@ -41,7 +41,10 @@ void CLevelMgr::tick()
     // 이전 프레임에 등록된 오브젝트들 clear
     m_CurLevel->clear();
 
-    if (m_CurLevel->GetState() != LEVEL_STATE::STOP)
+    // Play, Simulate 상태 이거나
+    // Pause 상태에선 Step중인 경우에만 재생
+    LEVEL_STATE State = m_CurLevel->GetState();
+    if (State == LEVEL_STATE::PLAY || State == LEVEL_STATE::SIMULATE || (State == LEVEL_STATE::PAUSE && m_CurLevel->m_StepFrames > 0))
     {
         m_CurLevel->tick();
     }

--- a/Project/Engine/CModelEditor.cpp
+++ b/Project/Engine/CModelEditor.cpp
@@ -618,26 +618,32 @@ void CModelEditor::DrawDetails()
 
         if (ImGui_AlignButton("Load Model", 0.f))
         {
-            std::filesystem::path filePath = OpenFileDialog(m_RecentPath, TEXT("FBX Files\0*.fbx\0모든 파일(*.*)\0*.*\0"));
+            vector<wstring> vec;
+            OpenFileDialog(vec, m_RecentPath, {{L"FBX Files", L"*.fbx"}});
 
-            // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
-            if (!filePath.empty())
+            for (wstring& strPath : vec)
             {
-                // .fbx 포맷이 아닌 경우
-                if (L".fbx" != filePath.extension())
+                std::filesystem::path filePath = strPath;
+
+                // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
+                if (!filePath.empty())
                 {
-                    MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                }
-                // 경로에 Content 폴더가 포함되지 않은 경우
-                else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
-                {
-                    m_RecentPath = L"fbx\\";
-                    MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                }
-                else
-                {
-                    m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
-                    CAssetMgr::GetInst()->AsyncLoadFBX(filePath.lexically_relative(CPathMgr::GetContentPath()));
+                    // .fbx 포맷이 아닌 경우
+                    if (L".fbx" != filePath.extension())
+                    {
+                        MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                    }
+                    // 경로에 Content 폴더가 포함되지 않은 경우
+                    else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
+                    {
+                        m_RecentPath = L"fbx\\";
+                        MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                    }
+                    else
+                    {
+                        m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
+                        CAssetMgr::GetInst()->AsyncLoadFBX(filePath.lexically_relative(CPathMgr::GetContentPath()));
+                    }
                 }
             }
         }
@@ -771,27 +777,33 @@ void CModelEditor::DrawDetails()
                 ImGui::SameLine();
                 if (ImGui_AlignButton("Import Animation##ModelEditorDetails", 1.f))
                 {
-                    std::filesystem::path filePath = OpenFileDialog(m_RecentPath, TEXT("FBX Files\0*.fbx\0모든 파일(*.*)\0*.*\0"));
+                    vector<wstring> vec;
+                    OpenFileDialog(vec, m_RecentPath, {{L"FBX Files", L"*.fbx"}});
 
-                    // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
-                    if (!filePath.empty())
+                    for (wstring& strPath : vec)
                     {
-                        // .fbx 포맷이 아닌 경우
-                        if (L".fbx" != filePath.extension())
+                        std::filesystem::path filePath = strPath;
+
+                        // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
+                        if (!filePath.empty())
                         {
-                            MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                        }
-                        // 경로에 Content 폴더가 포함되지 않은 경우
-                        else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
-                        {
-                            m_RecentPath = L"fbx\\";
-                            MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                        }
-                        else
-                        {
-                            m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
-                            CAssetMgr::GetInst()->AsyncLoadAnimationFBX(m_ModelObj->Animator()->GetSkeletalMesh(),
-                                                                        filePath.lexically_relative(CPathMgr::GetContentPath()));
+                            // .fbx 포맷이 아닌 경우
+                            if (L".fbx" != filePath.extension())
+                            {
+                                MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                            }
+                            // 경로에 Content 폴더가 포함되지 않은 경우
+                            else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
+                            {
+                                m_RecentPath = L"fbx\\";
+                                MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                            }
+                            else
+                            {
+                                m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
+                                CAssetMgr::GetInst()->AsyncLoadAnimationFBX(m_ModelObj->Animator()->GetSkeletalMesh(),
+                                                                            filePath.lexically_relative(CPathMgr::GetContentPath()));
+                            }
                         }
                     }
                 }

--- a/Project/Engine/CModelEditor.cpp
+++ b/Project/Engine/CModelEditor.cpp
@@ -625,25 +625,28 @@ void CModelEditor::DrawDetails()
             {
                 std::filesystem::path filePath = strPath;
 
-                // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
-                if (!filePath.empty())
+                // 경로가 입력되지 않은 경우
+                if (filePath.empty())
                 {
-                    // .fbx 포맷이 아닌 경우
-                    if (L".fbx" != filePath.extension())
-                    {
-                        MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                    }
-                    // 경로에 Content 폴더가 포함되지 않은 경우
-                    else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
-                    {
-                        m_RecentPath = L"fbx\\";
-                        MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                    }
-                    else
-                    {
-                        m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
-                        CAssetMgr::GetInst()->AsyncLoadFBX(filePath.lexically_relative(CPathMgr::GetContentPath()));
-                    }
+                    m_RecentPath = L"fbx\\";
+                    MessageBox(nullptr, L"경로가 올바르지 않습니다.", L"모델 로딩 실패", MB_ICONHAND);
+                }
+                // .fbx 포맷이 아닌 경우
+                else if (L".fbx" != filePath.extension())
+                {
+                    MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                }
+                // 경로에 Content 폴더가 포함되지 않은 경우
+                else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
+                {
+                    m_RecentPath = L"fbx\\";
+                    MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                }
+                // 모델 로딩
+                else
+                {
+                    m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
+                    CAssetMgr::GetInst()->AsyncLoadFBX(filePath.lexically_relative(CPathMgr::GetContentPath()));
                 }
             }
         }
@@ -784,26 +787,29 @@ void CModelEditor::DrawDetails()
                     {
                         std::filesystem::path filePath = strPath;
 
-                        // 취소, 닫기 버튼 체크를 클릭하지 않은 경우
-                        if (!filePath.empty())
+                        // 경로가 입력되지 않은 경우
+                        if (filePath.empty())
                         {
-                            // .fbx 포맷이 아닌 경우
-                            if (L".fbx" != filePath.extension())
-                            {
-                                MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                            }
-                            // 경로에 Content 폴더가 포함되지 않은 경우
-                            else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
-                            {
-                                m_RecentPath = L"fbx\\";
-                                MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
-                            }
-                            else
-                            {
-                                m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
-                                CAssetMgr::GetInst()->AsyncLoadAnimationFBX(m_ModelObj->Animator()->GetSkeletalMesh(),
-                                                                            filePath.lexically_relative(CPathMgr::GetContentPath()));
-                            }
+                            m_RecentPath = L"fbx\\";
+                            MessageBox(nullptr, L"경로가 올바르지 않습니다.", L"모델 로딩 실패", MB_ICONHAND);
+                        }
+                        // .fbx 포맷이 아닌 경우
+                        else if (L".fbx" != filePath.extension())
+                        {
+                            MessageBox(nullptr, L"fbx 포맷 파일이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                        }
+                        // 경로에 Content 폴더가 포함되지 않은 경우
+                        else if (string::npos == wstring(filePath).find(CPathMgr::GetContentPath()))
+                        {
+                            m_RecentPath = L"fbx\\";
+                            MessageBox(nullptr, L"Content 폴더에 존재하는 모델이 아닙니다.", L"모델 로딩 실패", MB_ICONHAND);
+                        }
+                        // 모델 로딩
+                        else
+                        {
+                            m_RecentPath = filePath.lexically_relative(CPathMgr::GetContentPath()).parent_path();
+                            CAssetMgr::GetInst()->AsyncLoadAnimationFBX(m_ModelObj->Animator()->GetSkeletalMesh(),
+                                                                        filePath.lexically_relative(CPathMgr::GetContentPath()));
                         }
                     }
                 }

--- a/Project/Engine/COutliner.cpp
+++ b/Project/Engine/COutliner.cpp
@@ -307,7 +307,7 @@ void COutliner::render()
             CCamera* pCam = CRenderMgr::GetInst()->GetMainCamera();
             Vec3 pos = pCam->Transform()->GetWorldPos();
             Vec3 dir = pCam->Transform()->GetWorldDir(DIR_TYPE::FRONT);
-            pos += dir.Normalize() * 5.f;
+            pos += dir.Normalize() * 5.f * CPhysicsMgr::GetInst()->GetPPM();
             pObj->Transform()->SetLocalPos(pos);
 
             GamePlayStatic::SpawnGameObject(pObj, 0);
@@ -353,7 +353,7 @@ void COutliner::render()
                 CCamera* pCam = CRenderMgr::GetInst()->GetMainCamera();
                 Vec3 pos = pCam->Transform()->GetWorldPos();
                 Vec3 dir = pCam->Transform()->GetWorldDir(DIR_TYPE::FRONT);
-                pos += dir.Normalize() * 5.f;
+                pos += dir.Normalize() * 5.f * CPhysicsMgr::GetInst()->GetPPM();
                 pObj->Transform()->SetLocalPos(pos);
 
                 GamePlayStatic::SpawnGameObject(pObj, pObj->GetLayerIdx());

--- a/Project/Engine/CSkyBox.cpp
+++ b/Project/Engine/CSkyBox.cpp
@@ -18,7 +18,6 @@ CSkyBox::CSkyBox()
 
 CSkyBox::~CSkyBox()
 {
-    ClearData();
 }
 
 void CSkyBox::finaltick()

--- a/Project/Engine/CTransform.cpp
+++ b/Project/Engine/CTransform.cpp
@@ -135,6 +135,9 @@ void CTransform::UpdateData()
 
 void CTransform::SetDirection(Vec3 _Forward)
 {
+    if (_Forward == Vec3::Zero)
+        return;
+
     _Forward.Normalize();
     Vec3 Up = Vec3(0.f, 1.f, 0.f);
 
@@ -155,24 +158,27 @@ void CTransform::SetDirection(Vec3 _Forward)
 
 void CTransform::Slerp(Vec3 _TowardDir, float _t)
 {
-    Vec3 FrontDir = GetWorldDir(DIR_TYPE::FRONT);
-    _TowardDir.y = 0.f; // Y축 고정
-    _TowardDir.Normalize();
-
     // FrontDir 와 TowardDir 가 비슷한 방향이면 보간 X
-    if (_TowardDir.Dot(FrontDir) >= cosf(0.f) - 1e-5f)
+    if (_TowardDir == Vec3::Zero || _TowardDir.Dot(GetWorldDir(DIR_TYPE::FRONT)) >= cosf(0.f) - 1e-5f)
         return;
 
-    // UpVector Y축 기준
-    Vec3 up = Vec3(0.f, 1.f, 0.f);
-    // 예외처리 Dir 이 Vec3(0.f, 0.f, -1.f)인경우 Up벡터가 반전됨
-    if (FrontDir == Vec3(0.f, 0.f, -1.f))
-    {
-        up = Vec3(0.f, -1.f, 0.f);
-    }
+    _TowardDir.Normalize();
+    Vec3 Up = Vec3(0.f, 1.f, 0.f);
 
-    Quat TowardQuaternion = Quat::LookRotation(_TowardDir, up);
-    Quat SlerpQuat = Quat::Slerp(GetWorldQuaternion(), TowardQuaternion, _t);
+    Vec3 Right = Up.Cross(_TowardDir);
+    Right.Normalize();
+
+    Up = _TowardDir.Cross(Right);
+    Up.Normalize();
+
+    Matrix rotationMatrix = Matrix();
+    rotationMatrix.Forward(-_TowardDir);
+    rotationMatrix.Up(Up);
+    rotationMatrix.Right(Right);
+
+    Quat TowardQuat = Quat::CreateFromRotationMatrix(rotationMatrix);
+
+    Quat SlerpQuat = Quat::Slerp(GetWorldQuaternion(), TowardQuat, _t);
     SetWorldRotation(SlerpQuat);
 }
 

--- a/Project/Engine/CTransform.cpp
+++ b/Project/Engine/CTransform.cpp
@@ -133,12 +133,24 @@ void CTransform::UpdateData()
     pCB->UpdateData();
 }
 
-void CTransform::SetDirection(Vec3 _Forward, Vec3 _Up)
+void CTransform::SetDirection(Vec3 _Forward)
 {
     _Forward.Normalize();
-    _Up.Normalize();
+    Vec3 Up = Vec3(0.f, 1.f, 0.f);
 
-    Transform()->SetWorldRotation(Quat::LookRotation(_Forward, _Up));
+    Vec3 Right = Up.Cross(_Forward);
+    Right.Normalize();
+
+    Up = _Forward.Cross(Right);
+    Up.Normalize();
+
+    Matrix rotationMatrix = Matrix();
+    rotationMatrix.Forward(-_Forward);
+    rotationMatrix.Up(Up);
+    rotationMatrix.Right(Right);
+
+    Quat Rot = Quat::CreateFromRotationMatrix(rotationMatrix);
+    Transform()->SetLocalRotation(Rot);
 }
 
 void CTransform::Slerp(Vec3 _TowardDir, float _t)

--- a/Project/Engine/CTransform.cpp
+++ b/Project/Engine/CTransform.cpp
@@ -158,25 +158,37 @@ void CTransform::SetDirection(Vec3 _Forward)
 
 void CTransform::Slerp(Vec3 _TowardDir, float _t)
 {
-    Vec3 FrontDir = GetWorldDir(DIR_TYPE::FRONT);
-    _TowardDir.y = 0.f; // Y축 고정
     _TowardDir.Normalize();
-
     // FrontDir 와 TowardDir 가 비슷한 방향이면 보간 X
-    if (_TowardDir.Dot(FrontDir) >= cosf(0.f) - 1e-5f)
+    if (_TowardDir == Vec3::Zero || _TowardDir.Dot(GetWorldDir(DIR_TYPE::FRONT)) >= 1.f - 1e-5f)
         return;
 
-    // UpVector Y축 기준
-    Vec3 up = Vec3(0.f, 1.f, 0.f);
-    // 예외처리 Dir 이 Vec3(0.f, 0.f, -1.f)인경우 Up벡터가 반전됨
-    if (FrontDir == Vec3(0.f, 0.f, -1.f))
-    {
-        up = Vec3(0.f, -1.f, 0.f);
-    }
+    // 회전 축 정렬
+    Vec3 Up = Vec3(0.f, 1.f, 0.f);
 
-    Quat TowardQuaternion = Quat::LookRotation(_TowardDir, up);
-    Quat SlerpQuat = Quat::Slerp(GetWorldQuaternion(), TowardQuaternion, _t);
-    SetWorldRotation(SlerpQuat);
+    Vec3 Right = Up.Cross(_TowardDir);
+    Right.Normalize();
+
+    Up = _TowardDir.Cross(Right);
+    Up.Normalize();
+
+    // 회전 행렬 생성
+    Matrix RotationMatrix = Matrix();
+    RotationMatrix.Forward(-_TowardDir);
+    RotationMatrix.Up(Up);
+    RotationMatrix.Right(Right);
+
+    // Slerp
+    Quat SlerpQuat = Quat::Slerp(GetWorldQuaternion(), Quat::CreateFromRotationMatrix(RotationMatrix), _t);
+
+    // Slerp 계산된 쿼터니언 으로부터 회전 행렬 생성
+    RotationMatrix = Matrix::CreateFromQuaternion(SlerpQuat);
+
+    // 회전 행렬의 Forward Vector 추출
+    Vec3 LookDir = -RotationMatrix.Forward();
+
+    // 방향 설정
+    SetDirection(LookDir);
 }
 
 Quat CTransform::GetWorldQuaternion() const

--- a/Project/Engine/CTransform.h
+++ b/Project/Engine/CTransform.h
@@ -26,7 +26,7 @@ public:
     virtual void UpdateData() override;
 
 public:
-    void SetDirection(Vec3 _Forward, Vec3 _Up = Vec3(0.f, 1.f, 0.f));
+    void SetDirection(Vec3 _Forward);
     void Slerp(Vec3 _TowardDir, float _t);
 
 public:

--- a/Project/Engine/func.h
+++ b/Project/Engine/func.h
@@ -139,7 +139,9 @@ UINT LoadAssetRef(Ptr<T>& _Asset, FILE* _File)
 
 wstring OpenFileDialog(const wstring& strRelativePath, const wchar_t* filter = L"All\0*.*\0"); // 전체 경로 반환
 wstring SaveFileDialog(const wstring& strRelativePath, const wchar_t* filter = L"All\0*.*\0"); // 전체 경로 반환
-void OpenFileDialog(vector<wstring>& _FilesName, const wstring& _RelativePath = L"");
+void OpenFileDialog(vector<wstring>& _FilesName, const wstring& _RelativePath = L"",
+                    const vector<std::pair<wstring, wstring>>& filter = {
+                        {L"All Files", L"*.*"}, {L"Text Files", L"*.txt"}, {L"FBX Files", L"*.fbx"}});
 Vec2 LoadMeta(const wstring& _strMetaRelativePath);
 
 // =====================================

--- a/Project/Scripts/CEngineTestScript.cpp
+++ b/Project/Scripts/CEngineTestScript.cpp
@@ -41,8 +41,8 @@ void CEngineTestScript::begin()
 
 void CEngineTestScript::tick()
 {
+    SetDirection();
 
-    CharacterControllerTest();
     // AnimatorTest();
     //  QuaternionExample();
 
@@ -266,6 +266,20 @@ void CEngineTestScript::QuaternionExample()
 void CEngineTestScript::DetachObject()
 {
     GamePlayStatic::DetachObject(CLevelMgr::GetInst()->GetCurrentLevel()->FindObjectByName(L"TestObj"));
+}
+
+void CEngineTestScript::SetDirection()
+{
+    CGameObject* pTarget = CLevelMgr::GetInst()->GetCurrentLevel()->FindObjectByName(L"Target");
+    if (pTarget)
+    {
+        Vec3 Dir = pTarget->Transform()->GetWorldPos() - Transform()->GetWorldPos();
+        Transform()->SetDirection(Dir);
+    }
+
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::FRONT), 1000.f, Vec3(0.f, 0.f, 1.f), true);
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::UP), 1000.f, Vec3(0.f, 1.f, 0.f), true);
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::RIGHT), 1000.f, Vec3(1.f, 0.f, 0.f), true);
 }
 
 void CEngineTestScript::OnCollisionEnter(CCollider* _OtherCollider)

--- a/Project/Scripts/CEngineTestScript.cpp
+++ b/Project/Scripts/CEngineTestScript.cpp
@@ -281,7 +281,7 @@ void CEngineTestScript::SetDirection()
     {
         Vec3 Dir = pTarget->Transform()->GetWorldPos() - Transform()->GetWorldPos();
         // Transform()->SetDirection(Dir);
-        Transform()->Slerp(Dir, DT);
+        Transform()->Slerp(Dir, DT * 5.f);
     }
 
     GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::FRONT), 1000.f, Vec3(0.f, 0.f, 1.f), true);

--- a/Project/Scripts/CEngineTestScript.cpp
+++ b/Project/Scripts/CEngineTestScript.cpp
@@ -41,13 +41,13 @@ void CEngineTestScript::begin()
 
 void CEngineTestScript::tick()
 {
-    CharacterControllerTest();
+    // CharacterControllerTest();
 
     GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::FRONT), 1000.f, Vec3(0.f, 0.f, 1.f), true);
     GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::UP), 1000.f, Vec3(0.f, 1.f, 0.f), true);
     GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::RIGHT), 1000.f, Vec3(1.f, 0.f, 0.f), true);
- 
-    // SetDirection();
+
+    SetDirection();
 
     // AnimatorTest();
     // QuaternionExample();
@@ -280,7 +280,8 @@ void CEngineTestScript::SetDirection()
     if (pTarget)
     {
         Vec3 Dir = pTarget->Transform()->GetWorldPos() - Transform()->GetWorldPos();
-        Transform()->SetDirection(Dir);
+        // Transform()->SetDirection(Dir);
+        Transform()->Slerp(Dir, DT);
     }
 
     GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::FRONT), 1000.f, Vec3(0.f, 0.f, 1.f), true);

--- a/Project/Scripts/CEngineTestScript.cpp
+++ b/Project/Scripts/CEngineTestScript.cpp
@@ -41,10 +41,16 @@ void CEngineTestScript::begin()
 
 void CEngineTestScript::tick()
 {
-    SetDirection();
+    CharacterControllerTest();
+
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::FRONT), 1000.f, Vec3(0.f, 0.f, 1.f), true);
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::UP), 1000.f, Vec3(0.f, 1.f, 0.f), true);
+    GamePlayStatic::DrawDebugLine(Transform()->GetWorldPos(), Transform()->GetWorldDir(DIR_TYPE::RIGHT), 1000.f, Vec3(1.f, 0.f, 0.f), true);
+ 
+    // SetDirection();
 
     // AnimatorTest();
-    //  QuaternionExample();
+    // QuaternionExample();
 
     //// Bullet Test
     // if (KEY_TAP(KEY::N))

--- a/Project/Scripts/CEngineTestScript.h
+++ b/Project/Scripts/CEngineTestScript.h
@@ -19,6 +19,7 @@ private:
     void AnimatorTest();
     void QuaternionExample();
     void DetachObject();
+    void SetDirection();
 
 private:
     virtual void OnCollisionEnter(CCollider* _OtherCollider);

--- a/Project/Scripts/CKirbyMoveController.cpp
+++ b/Project/Scripts/CKirbyMoveController.cpp
@@ -200,7 +200,7 @@ void CKirbyMoveController::SetDir()
     }
 
     // 보간을 통해 현재 방향 설정
-    Transform()->Slerp(-m_TowardDir, DT * m_RotSpeed);
+    Transform()->Slerp(m_TowardDir, DT * m_RotSpeed);
 }
 
 void CKirbyMoveController::Move()

--- a/Project/Scripts/CKirbyObject.cpp
+++ b/Project/Scripts/CKirbyObject.cpp
@@ -130,15 +130,17 @@ void CKirbyObject::DropObjectEnter()
     Vec3 Force = Vec3(0.f, 1.f, 0.f) + BackDir;
     Force = Force.Normalize() * 3.f;
 
+    // Vec3 FrontDir = -BackDir;
+    //  Vec3 up = Vec3(0.f, 1.f, 0.f);
+    //  if (FrontDir == Vec3(0.f, 0.f, -1.f))
+    //{
+    //      up = Vec3(0.f, -1.f, 0.f);
+    //  }
+
+    // pObj->Transform()->SetDirection(-FrontDir, up);
+
     Vec3 FrontDir = -BackDir;
-    Vec3 up = Vec3(0.f, 1.f, 0.f);
-    if (FrontDir == Vec3(0.f, 0.f, -1.f))
-    {
-        up = Vec3(0.f, -1.f, 0.f);
-    }
-
-    pObj->Transform()->SetDirection(-FrontDir, up);
-
+    pObj->Transform()->SetDirection(-FrontDir);
 
     pObj->Transform()->SetWorldPos(InitPos);
     pObj->Rigidbody()->AddForce(Force, ForceMode::Impulse);

--- a/Project/Scripts/CKirbyObject_VendingMachine.cpp
+++ b/Project/Scripts/CKirbyObject_VendingMachine.cpp
@@ -31,8 +31,6 @@ void CKirbyObject_VendingMachine::AttackStart()
             ChangeState(L"ATTACK_END");
         }
     }
-
-
 }
 
 void CKirbyObject_VendingMachine::AttackStartEnter()
@@ -59,12 +57,14 @@ void CKirbyObject_VendingMachine::AttackStartEnter()
     // 초기값 세팅
     // 예외처리 Dir 이 Vec3(0.f, 0.f, -1.f)인경우 Up벡터가 반전됨
     Vec3 up = Vec3(0.f, 1.f, 0.f);
-    if (KirbyWorldDir == Vec3(0.f, 0.f, -1.f))
-    {
-        up = Vec3(0.f, -1.f, 0.f);
-    }
+    // if (KirbyWorldDir == Vec3(0.f, 0.f, -1.f))
+    //{
+    //     up = Vec3(0.f, -1.f, 0.f);
+    // }
 
-    CanJuiceInst->Transform()->SetDirection(-KirbyWorldDir, up);
+    // CanJuiceInst->Transform()->SetDirection(-KirbyWorldDir, up);
+
+    CanJuiceInst->Transform()->SetDirection(-KirbyWorldDir);
     CanJuiceInst->Transform()->SetWorldPos(KirbyPos + Offset);
 
     GamePlayStatic::SpawnGameObject(CanJuiceInst, CanJuiceInst->GetLayerIdx());
@@ -75,7 +75,6 @@ void CKirbyObject_VendingMachine::AttackStartExit()
     PLAYERCTRL->UnlockMove();
     PLAYERCTRL->UnlockJump();
     PLAYERCTRL->UnlockDirection();
-
 }
 
 void CKirbyObject_VendingMachine::AttackEnd()
@@ -135,7 +134,7 @@ void CKirbyObject_VendingMachine::ChangeObjectEnter()
 
     PLAYERCTRL->SetSpeed(5.f);
     m_SaveJumpPower = PLAYERCTRL->GetJumpPower();
-    PLAYERCTRL->SetJumpPower(m_SaveJumpPower/2.f);
+    PLAYERCTRL->SetJumpPower(m_SaveJumpPower / 2.f);
 
     // 콜라이더 & 바디콜라이더 크기 세팅
     PLAYER->CharacterController()->SetCenter(Vec3(0.f, 200.f, 0.f));


### PR DESCRIPTION
1. [feat : Transform Slerp() 함수 Y축 고정 → 어떤 방향이든 지원되도록 수정](https://github.com/devJSY/TinyEngine/commit/775a3f3361837c5c146ba1574de746af5031a9b5)

2. [feat : Model Editor OpenFileDialog() 여러개의 .fbx 파일을 선택할 수 있도록 기능 보강](https://github.com/devJSY/TinyEngine/commit/ea9d5c8103c112543d22bd5a167bb2f026ae1fda)

3.  [chore : 프리팹, 매시데이터 인스턴싱 시 오브젝트 스폰위치 카메라 Front * 5 * PhysicsMgr PPM 으로 변경](https://github.com/devJSY/TinyEngine/commit/65e2469f6cfe70425fa700767df3fc7fd2f69c78)

4. [fix : Level Pause 상태 에서 tick이 돌던 버그 수정](https://github.com/devJSY/TinyEngine/commit/7ee19bcce9eb771c43eafdb71695fa40265165a0)