### PR TITLE
Hotfix : PhsyicsMgr Scale 0예외처리 추가

### DIFF
--- a/Project/Engine/CPhysicsMgr.cpp
+++ b/Project/Engine/CPhysicsMgr.cpp
@@ -676,13 +676,6 @@ void CPhysicsMgr::AddPhysicsObject(CGameObject* _GameObject)
         }
     }
 
-    // 설정한 질량 업데이트
-    if (nullptr != pRigidbody)
-    {
-        PxRigidBody* body = (PxRigidBody*)pRigidbody->m_RuntimeBody;
-        PxRigidBodyExt::updateMassAndInertia(*body, pRigidbody->m_Mass);
-    }
-
     // Physics Object 추가
     RigidActor->userData = (void*)_GameObject;
     m_Scene->addActor(*RigidActor);

--- a/Project/Engine/CPhysicsMgr.cpp
+++ b/Project/Engine/CPhysicsMgr.cpp
@@ -383,9 +383,23 @@ void CPhysicsMgr::AddPhysicsObject(CGameObject* _GameObject)
     if (nullptr == m_Scene || nullptr == _GameObject || !_GameObject->IsActive() || _GameObject->IsDead())
         return;
 
+    CTransform* pTr = _GameObject->Transform();
+
+    Vec3 WorldPos = pTr->GetWorldPos();
+    Quat WorldQuat = pTr->GetWorldQuaternion();
+    Vec3 WorldScale = pTr->GetWorldScale();
+
+    const float WorldRatio = pTr->GetWorldRatio();
+
+    WorldPos /= m_PPM;
+    WorldScale /= m_PPM;
+
+    // Scale 예외처리
+    if (WorldScale.x <= 0.f || WorldScale.y <= 0.f || WorldScale.z <= 0.f)
+        return;
+
     AddCharacterControllerObject(_GameObject);
 
-    CTransform* pTr = _GameObject->Transform();
     CRigidbody* pRigidbody = _GameObject->Rigidbody();
     CBoxCollider* pBoxCol = _GameObject->BoxCollider();
     CSphereCollider* pSphereCol = _GameObject->SphereCollider();
@@ -404,15 +418,6 @@ void CPhysicsMgr::AddPhysicsObject(CGameObject* _GameObject)
 
         return;
     }
-
-    Vec3 WorldPos = pTr->GetWorldPos();
-    Quat WorldQuat = pTr->GetWorldQuaternion();
-    Vec3 WorldScale = pTr->GetWorldScale();
-
-    const float WorldRatio = pTr->GetWorldRatio();
-
-    WorldPos /= m_PPM;
-    WorldScale /= m_PPM;
 
     // World Space 기준 위치, 회전상태 적용
     PxTransform PxTr = PxTransform(WorldPos.x, WorldPos.y, WorldPos.z, PxQuat(WorldQuat.x, WorldQuat.y, WorldQuat.z, WorldQuat.w));
@@ -674,6 +679,13 @@ void CPhysicsMgr::AddPhysicsObject(CGameObject* _GameObject)
             shape->userData = (void*)pMeshCol;
             pMeshCol->m_RuntimeShape = shape;
         }
+    }
+
+    // 설정한 질량 업데이트
+    if (nullptr != pRigidbody)
+    {
+        PxRigidBody* body = (PxRigidBody*)pRigidbody->m_RuntimeBody;
+        PxRigidBodyExt::updateMassAndInertia(*body, body->getMass());
     }
 
     // Physics Object 추가


### PR DESCRIPTION
## Rigidbody + Sphrer Collider 를 가진 상태에서 트랜스폼 스케일이 0 이되는 경우 Assert() 걸리는 버그 수정
- [fix : PhsyicsMgr Scale 0예외처리 추가](https://github.com/devJSY/TinyEngine/commit/7623c5d0507a2bc329077caddbbf42597e9dee78)